### PR TITLE
Refactor HomePageContent and update sidebar options

### DIFF
--- a/src/features/SideBar.tsx
+++ b/src/features/SideBar.tsx
@@ -94,12 +94,12 @@ const SideBar: React.FC<SideBarProps> = () => {
           {/* Bottom Menu Items */}
           <div className="menu-bottom">
             <Menu>
-              <MenuItem
+              {/* <MenuItem
                 className="menu-item menu-item-upgrade"
                 icon={<RocketOutlined />}
               >
                 שדרוג
-              </MenuItem>
+              </MenuItem> */}
               <MenuItem
                 className="menu-item menu-item-profile"
                 icon={<UserOutlined />}

--- a/src/ui/HomePageContent.tsx
+++ b/src/ui/HomePageContent.tsx
@@ -1,13 +1,7 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import "./HomePageContent.css";
 import LessonsContext, { Topic, Question } from "../context/LessonsContext";
-
-const predefinedSubjects = [
-  "חיבור עד 10",
-  "חיסור עד 10",
-  "כפל עד 10",
-  "חלוקה עד 10",
-];
+import { subjectsByGrade } from "../components/SubjectByGrade";
 
 export const generateTopic = (
   subject: string,
@@ -41,6 +35,13 @@ const HomePageContent: React.FC = () => {
   const [selectedSubject, setSelectedSubject] = useState<string>("");
   const [selectedRank, setSelectedRank] = useState<number>(1);
   const [showAddModal, setShowAddModal] = useState(false);
+  const [predefinedSubjects, setPredefinedSubjects] = useState<string[]>([]);
+  useEffect(() => {
+    const rawGrade = localStorage.getItem("grade") || "";
+    if (rawGrade && subjectsByGrade[rawGrade]) {
+      setPredefinedSubjects(subjectsByGrade[rawGrade]);
+    }
+  }, []);
 
   if (!lessonsContext) return null;
 


### PR DESCRIPTION
Refactor HomePageContent to dynamically set predefined subjects based on the user's grade stored in local storage. Remove the plans option from the sidebar for a cleaner interface.